### PR TITLE
Better UX for autocomplete, akin to Chrome console

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -181,7 +181,7 @@ JanewayClass.setProperty('default_indicator_options', {
  *
  * @author   Jelle De Loecker   <jelle@develry.be>
  * @since    0.2.3
- * @version  0.3.5
+ * @version  0.3.4
  */
 JanewayClass.setProperty('default_config', {
 	autocomplete: {
@@ -197,7 +197,7 @@ JanewayClass.setProperty('default_config', {
 	caller_info: {
 		stack_size: 6,
 		max_filename_length: 10,
-		min_length: 26
+		min_length: 25
 	},
 	properties: {
 		alike_objects  : false,
@@ -1049,6 +1049,7 @@ JanewayClass.setMethod(function popup(id, options) {
 			this.open_popups[id].destroy();
 		}
 
+		this.screen.render();
 		return;
 	}
 
@@ -1158,8 +1159,10 @@ JanewayClass.setMethod(function autocomplete(cmd, key) {
 		return;
 	}
 
-	if (!cmd && !key) {
-		return this.autocomplete_list = this.popup('autocomplete', false);
+	if (!cmd || !key) {
+		this.autocomplete_list = this.popup('autocomplete', false);
+		this.screen.render();
+		return;
 	}
 
 	this.autocomplete_prefix = null;
@@ -1868,16 +1871,29 @@ JanewayClass.setMethod(function start(options, callback) {
 		path = that.autocomplete_prefix || '';
 
 		if (temp) {
+			var final = path + temp.content;
+
 			// Set the value and move to the end
-			cli.setValue(path + temp.content, true);
+			cli.setValue(final, true);
 			that.autocomplete();
 		}
+	}
+
+	function deleteWord(cmd) {
+		var wordRegex = /\w+\s*$/
+		var matches = cmd.match(wordRegex)
+		if (matches && matches.length && matches[0]) {
+			return cmd.replace(wordRegex, '')
+		}
+
+		return cmd.slice(0, -1);
 	}
 
 	var current_keypress_time = 0,
 	    last_keypress_time = 0,
 	    current_key = null,
-	    last_key = null;
+	    last_key = null,
+			autocomplete_focused = false;
 
 	/**
 	 * Handle input of the CLI
@@ -1908,6 +1924,8 @@ JanewayClass.setMethod(function start(options, callback) {
 		// Enters appear as an "enter" first and a "return" afterwards,
 		// ignore those second returns
 		if (key.name == 'return' && last_key == 'enter') {
+			cli.setValue(cli.getValue().replace(/\n$/, ''), true);
+			that.autocomplete();
 			return;
 		}
 
@@ -1916,12 +1934,12 @@ JanewayClass.setMethod(function start(options, callback) {
 		} else if (key.name == 'pageup') {
 			that.scroll(-20, true);
 		} else if (key.name == 'enter' && key_speed > 24) {
-
-			if (that.autocomplete_list) {
-				return selectAutocomplete();
-			}
-
 			cmd = cli.getValue().trim();
+
+			if (autocomplete_focused && that.autocomplete_list) {
+				selectAutocomplete();
+				return;
+			}
 
 			// Reset the index
 			that.cli_history_index = -1;
@@ -1965,10 +1983,21 @@ JanewayClass.setMethod(function start(options, callback) {
 
 			that.evaluate(cmd);
 		} else {
-			if (key.ch == '.' || key.name == 'tab' || key.ch == '(') {
+			if (key.ch === '.' && autocomplete_focused) {
 				if (that.autocomplete_list) {
 					selectAutocomplete();
 				}
+			}
+
+			if (key.name == 'tab') {
+				if (that.autocomplete_list) {
+					selectAutocomplete();
+				}
+
+				cli.setValue(cmd, true);
+				this.autocomplete(cmd, key);
+				autocomplete_focused = false;
+				return;
 			}
 
 			cmd = cli.getValue();
@@ -1979,11 +2008,14 @@ JanewayClass.setMethod(function start(options, callback) {
 				// If the autocomplete list is open, listen to the arrow keys
 				if (that.autocomplete_list) {
 					if (key.name == 'up') {
+						autocomplete_focused = true
 						that.autocomplete_list.up(1);
 						that.autocomplete_list.render();
 					} else if (key.name == 'down') {
+						autocomplete_focused = true
 						that.autocomplete_list.down(1);
 					} else if (key.name == 'escape') {
+						autocomplete_focused = false
 						that.autocomplete();
 					}
 
@@ -2027,12 +2059,18 @@ JanewayClass.setMethod(function start(options, callback) {
 				}
 
 				return;
+			} else if (key.full === 'C-w') {
+				cmd = deleteWord(cmd)
+				cli.setValue(cmd, true);
+				screen.render()
 			} else if (key.name === 'backspace') {
 				cmd = cmd.slice(0, -1);
 			} else {
 				cmd += e;
 			}
+
 			that.autocomplete(cmd, key);
+			autocomplete_focused = false;
 		}
 	});
 


### PR DESCRIPTION
C-w key, aka Option+Backspace, aka "delete last word" support.
Enter only autocompletes after user scrolls through suggestion list (via the up or down keys), and does not append a return character.
Tab always autocompletes but does not append a tab character.
Dot autocompletes and appends . character, but only after user scrolls through list.